### PR TITLE
adding RFC version, alternate layout suggestion, slight reformatting

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -2,6 +2,7 @@
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - RFC PR: (leave this empty)
 - Ursa Issue: (leave this empty)
+- Version: (use whole numbers: 1, 2, 3, etc)
 
 # Summary
 [summary]: #summary
@@ -89,3 +90,8 @@ readers of your RFC with a fuller picture.
 - What related issues do you consider out of scope for this RFC that could be
   addressed in the future independently of the solution that comes out of this
   RFC?
+
+# Changelog
+[changelog]: #changelog
+
+- [10 Jan 2019] - v2 - a one-line summary of the changes in this version.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ merged into the RFC repository as a markdown file. At that point the RFC is
 "active" and may be implemented with the goal of eventual inclusion into Ursa.
 
   - Fork the RFC repo [RFC repository]
-  - Copy `0000-template.md` to `text/0000-my-feature.md` (where "my-feature" is
-    descriptive. don't assign an RFC number yet).
+  - Copy `0000-template.md` to `0000-my-feature.md` (where "my-feature" is
+    descriptive. Don't assign an RFC number yet). 
+  - If the RFC has supporting images or diagram files, also create a folder
+    called `0000-my-feature` and put them there.
   - Fill in the RFC. Put care into the details: RFCs that do not present
     convincing motivation, demonstrate understanding of the impact of the
     design, or are disingenuous about the drawbacks or alternatives tend to be
@@ -147,10 +149,10 @@ merged into the RFC repository as a markdown file. At that point the RFC is
 [The RFC life-cycle]: #the-rfc-life-cycle
 
 Once an RFC becomes "active" then authors may implement it and submit the
-change as a pull request to the corresponding Ursa repo. Being "active" is not a rubber
-stamp, and in particular still does not mean the change will ultimately be
-merged; it does mean that in principle all the major stakeholders have agreed
-to the change and are amenable to merging it.
+change as a pull request to the corresponding Ursa repo. Being "active" is not
+a rubber stamp, and in particular still does not mean the change will
+ultimately be merged; it does mean that in principle all the major stakeholders
+have agreed to the change and are amenable to merging it.
 
 Furthermore, the fact that a given RFC has been accepted and is "active"
 implies nothing about what priority is assigned to its implementation, nor does


### PR DESCRIPTION
My suggestions from the template discussion didn't get landed/considered. I am submitting them here so we can discuss.

The first change is adding a version to the header and a changelog to the footer of an RFC. If RFCs will get updated in subsequect PRs as things evolve, I think we should track that evolution explicitly in the RFC.

The second change is suggesting that instead of having the RFCs in a "text" subfolder that we just keep them in the root. Then I also added the suggestion of having subfolders for supporting files such as images or diagrams. The subfolder will be named the same as the RFC document.